### PR TITLE
Fixed "implicit declaration of function 'sleep_us' " error

### DIFF
--- a/lib/nrf24l01/spi_manager/spi_manager.h
+++ b/lib/nrf24l01/spi_manager/spi_manager.h
@@ -21,7 +21,7 @@
 
 #include "error_manager.h"
 #include "hardware/spi.h"
-
+#include <pico/time.h>
 
 // corresponding SPI instance (SPI_0, SPI_1) when checking GPIO pins
 typedef enum spi_instance_e { SPI_0, SPI_1 } spi_instance_t;


### PR DESCRIPTION
I had an error while compiling that basically said 'sleep_us' was implicitly declared and after including pico/time.h in spi_manager.h everything compiled without any errors