### PR TITLE
Update nrf24_driver.h

### DIFF
--- a/lib/nrf24l01/nrf24_driver.h
+++ b/lib/nrf24l01/nrf24_driver.h
@@ -19,7 +19,7 @@
 #ifndef NRF24L01_H
 #define NRF24L01_H
 
-#include "error_manager.h"
+#include "error_manager/error_manager.h"
 #include "hardware/spi.h"
 
 


### PR DESCRIPTION
It's to need change the include from "error_manager.h" to "error_manager/error_manager.h". Because the directory needs to be explicit

Closes #10 